### PR TITLE
PCA (ropls) and consistent plots

### DIFF
--- a/vignettes/workflow.Rmd
+++ b/vignettes/workflow.Rmd
@@ -2,7 +2,7 @@
 title: "Workflow"
 author:
 - name: Ahmed Mohamed
-  affiliation: Prescision & Systems Biomedicine, QIMR Berghofer, Australia
+  affiliation: Precision & Systems Biomedicine, QIMR Berghofer, Australia
 date: "`r Sys.Date()`"
 output:
   html_document:


### PR DESCRIPTION
The PCA function now uses ropls instead of prcomp. The pca/mvaobject created contains the ropls summary, which was missing from the previous function. 

Consistent plots are now made so that PCA and OPLS/OPLS-DA score plots have the same style. The new PCA plot now correctly displays R2X, and variance explained by the first and second component. 

Confirmed that the new functions work well by running the vignette. 