### PR TITLE
adding in package to .data_internal

### DIFF
--- a/R/utils-misc.R
+++ b/R/utils-misc.R
@@ -19,7 +19,7 @@
 
 .data_internal <- function(dataset) {
   if (!exists(dataset, envir = .myDataEnv)) {
-    utils::data(list = c(dataset), envir = .myDataEnv)
+    utils::data(list = c(dataset), envir = .myDataEnv, package = "lipidr")
   }
 }
 


### PR DESCRIPTION
If someone tries to use the package without doing library(lipidr) first (eg lipidr::annotate_lipids), then data doesnt know where to find the data, and it will fail. I know b/c I tried to use it via `lipidr::annotate_lipids` and it will fail.

By explicitly adding the package here, it should work both using library() first and doing it without attaching it.